### PR TITLE
Make cpan faster

### DIFF
--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -447,6 +447,7 @@ my @default_runargs    = ();
 my @default_modules    = ();
 my @default_mirrors    = (qw( http://search.cpan.org/CPAN/ ));
 
+return if defined($::{"no_run"});
 setup_user();
 print $USER "\n";
 print $USER "============================================================\n";

--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -292,6 +292,19 @@ my $LOGFILE;
 my $COMMAND;
 my $USER;
 
+sub caller_line {
+        my $i = 0;
+        my ($rc, $rc_prev, $func);
+        while (1) {
+                my @v = caller($i);
+                defined($v[0]) or last;
+                $rc_prev = $rc;
+                ($rc, $func) = @v[2..3];
+                $i++;
+        };
+        $func ne "(eval)"? $rc: $rc_prev;
+}
+
 sub setup_user {
         open($USER, ">&", \*STDOUT) || die;
 }
@@ -306,7 +319,7 @@ sub setup_log {
 sub print_and_system {
         my ($cmd) = @_;
         my $exitcode;
-        my (undef, undef, $line) = caller;
+        my $line = caller_line();
 
         open(STDOUT, ">&", $LOGFILE) || die;
         open(STDERR, ">&", $LOGFILE) || die;
@@ -323,7 +336,7 @@ sub print_and_system {
 
 sub print_and_system_out {
         my ($cmd) = @_;
-        my (undef, undef, $line) = caller;
+        my $line = caller_line();
         
         print $COMMAND $cmd, "\n";
         print $LOGFILE $cmd, "\n";
@@ -333,9 +346,7 @@ sub print_and_system_out {
 
 sub print_and_qx {
         my ($cmd) = @_;
-        my (undef, undef, $line0, $func0) = caller(0);
-        my (undef, undef, $line1, $func1) = caller(1);
-        my $line = defined($func1) && $func1 eq 'main::print_and_qx_chomp'? $line1: $line0;
+        my $line = caller_line();
         my $exitcode;
         my $out;
  

--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -290,6 +290,11 @@ my $OLDSTDOUT;
 my $OLDSTDERR;
 my $LOGFILE;
 my $COMMAND;
+my $USER;
+
+sub setup_user {
+        open($USER, ">&", \*STDOUT) || die;
+}
 
 sub setup_log {
         open($OLDSTDOUT, ">&", \*STDOUT) || die;
@@ -303,12 +308,11 @@ sub print_and_system {
         my $exitcode;
         my (undef, undef, $line) = caller;
 
-        print $COMMAND $cmd, "\n";
-
         open(STDOUT, ">&", $LOGFILE) || die;
         open(STDERR, ">&", $LOGFILE) || die;
 
-        print $cmd."\n";
+        print $COMMAND $cmd, "\n";
+        print $LOGFILE $cmd, "\n";
         $exitcode = system ($cmd);
 
         open(STDOUT, ">&", $OLDSTDOUT) || die;
@@ -322,9 +326,8 @@ sub print_and_system_out {
         my (undef, undef, $line) = caller;
         
         print $COMMAND $cmd, "\n";
-
-        print $cmd."\n";
-        print $LOGFILE $cmd."\n";
+        print $LOGFILE $cmd, "\n";
+        print $USER    $cmd, "\n";
         system ($cmd) == 0 || die "$0($line): $cmd ($?>>".($?>>8).")"; 
 }
 
@@ -337,10 +340,10 @@ sub print_and_qx {
         my $out;
  
         print $COMMAND $cmd, "\n";
-
+        print $LOGFILE $cmd, "\n";
         $out = qx($cmd 2>&1);
         $exitcode = $?;
-        print $LOGFILE "$cmd\n$out\n";
+        print $LOGFILE $out, "\n";
         $exitcode == 0 || die "$0($line): $cmd ($exitcode>>".($exitcode>>8).")";
  
         $out;
@@ -413,7 +416,7 @@ my $ok = GetOptions (
 
 if ($help) {
         exec("perldoc", "bootstrap-perl") or do {
-                print "\nPlease see 'perldoc bootstrap-perl' for help.\n";
+                print $USER "\nPlease see 'perldoc bootstrap-perl' for help.\n";
                 exit 0;
         }
 }
@@ -433,17 +436,18 @@ my @default_runargs    = ();
 my @default_modules    = ();
 my @default_mirrors    = (qw( http://search.cpan.org/CPAN/ ));
 
-print "\n";
-print "============================================================\n";
-print "Bootstrap Perl\n";
-print "============================================================\n";
+setup_user();
+print $USER "\n";
+print $USER "============================================================\n";
+print $USER "Bootstrap Perl\n";
+print $USER "============================================================\n";
 
 # giturl "." means clone from local dir
 if ($giturl eq '.') {
         $giturl = getcwd;
         my $firstcommit = qx!git log --oneline 8d063cd8450e59ea1c611a2f4f5a21059a2804f1 2> /dev/null!;
         if ($firstcommit !~ /a "replacement" for awk and sed/) {
-                print "Local git repo does not look like it is Perl's.\n";
+                print $USER "Local git repo does not look like it is Perl's.\n";
                 exit 1;
         }
 }
@@ -514,11 +518,11 @@ sub installdeps_debian
 if ($installdeps) {
         my @SUPPORTED_DISTROS = (qw(debian));
         if (grep { /$installdeps/ } @SUPPORTED_DISTROS) {
-                print "Install dependencies for: $installdeps\n";
+                print $USER "Install dependencies for: $installdeps\n";
                 eval "installdeps_$installdeps()";
         } else {
-                print "Unsupported dependency installation for distro: $installdeps\n";
-                print "Allowed distros: ".join(", ", @SUPPORTED_DISTROS), "\n";
+                print $USER "Unsupported dependency installation for distro: $installdeps\n";
+                print $USER "Allowed distros: ".join(", ", @SUPPORTED_DISTROS), "\n";
                 exit 1;
         }
 }
@@ -565,7 +569,7 @@ $VERSION = eval("v$perl_revision.$perl_version.$perl_subversion");
 
 # cherry pick several bugfixes in 5.8/5.9 that break building
 if (v5.8.0 le $VERSION && $VERSION le v5.9.4) {
-        print "*** cherry-pick building fixes for older perl versions\n";
+        print $USER "*** cherry-pick building fixes for older perl versions\n";
         # FIX: <command-line>
         print_and_system qq!cd $build_path_perl && git cherry-pick -n cf14425e2bd169ce935f76d359f3253b51e441a0!;
         # FIX: rebuild / gcc -g
@@ -577,7 +581,7 @@ if (v5.8.0 le $VERSION && $VERSION le v5.9.4) {
 }
 
 if ($VERSION lt v5.14.0) {
-        print "*** cherry-pick: fix search libs in configure (all < 5.14.0)\n";
+        print $USER "*** cherry-pick: fix search libs in configure (all < 5.14.0)\n";
         print_and_system qq!cd $build_path_perl && git cherry-pick -n 40f026236b9959b7ad3260fedc6c66cd30bb7abc!;
 }       
 
@@ -586,8 +590,8 @@ if ($VERSION lt v5.14.0) {
 unless (defined $perl_revision && defined $perl_version)
 {
         no warnings 'uninitialized';
-        print "# Bummer! Unrecognized version schema ($gitdescribe).\n";
-        print "# ($perl_revision, $perl_version, $perl_subversion)\n";
+        print $USER "# Bummer! Unrecognized version schema ($gitdescribe).\n";
+        print $USER "# ($perl_revision, $perl_version, $perl_subversion)\n";
         exit 1;
 }
 
@@ -596,27 +600,27 @@ my $PREFIX               = $prefix || _perl_pathprefix($perl_revision, $perl_ver
 my $USETHREADS           = $usethreads ? "-Dusethreads"  : "";
 my $BIT64                = $bit64      ? "-Duse64bitall" : "";
 
-print "\n";
-print "============================================================\n\n";
-print "  Bootstrap Perl\n";
-print "  --------------\n\n";
-print "  version:        $version\n\n";
-print "  git-describe:   $gitdescribe\n\n";
-print "  git-changeset:  $gitchangeset\n\n";
-print "  codespeed name: $codespeed_executable\n\n";
-print "  PREFIX:         $PREFIX\n\n";
-print "  configureargs:  ".join("\n                  ", @confargs)."\n\n";
-print "  CPAN mirrors:   ".join("\n                  ", @CPANMIRRORS)."\n\n";
-print "  modules:        ".join("\n                  ", @MODULES)."\n\n";
-print "  scripts:        ".join("\n                  ", map { $_ ." ".join(" ", @RUNARGS) } @RUNSCRIPTS)."\n\n";
-print "============================================================\n\n";
+print $USER "\n";
+print $USER "============================================================\n\n";
+print $USER "  Bootstrap Perl\n";
+print $USER "  --------------\n\n";
+print $USER "  version:        $version\n\n";
+print $USER "  git-describe:   $gitdescribe\n\n";
+print $USER "  git-changeset:  $gitchangeset\n\n";
+print $USER "  codespeed name: $codespeed_executable\n\n";
+print $USER "  PREFIX:         $PREFIX\n\n";
+print $USER "  configureargs:  ".join("\n                  ", @confargs)."\n\n";
+print $USER "  CPAN mirrors:   ".join("\n                  ", @CPANMIRRORS)."\n\n";
+print $USER "  modules:        ".join("\n                  ", @MODULES)."\n\n";
+print $USER "  scripts:        ".join("\n                  ", map { $_ ." ".join(" ", @RUNARGS) } @RUNSCRIPTS)."\n\n";
+print $USER "============================================================\n\n";
 
 my @in_blead = grep { / blead$/ }
                map  { chomp ; $_ }
                print_and_qx qq!git branch --contains $gitchangeset!;
 if ($blead && !@in_blead) {
-        print "# Bummer!\n";
-        print "#   Use '--blead' only with commits in blead branch.\n";
+        print $USER "# Bummer!\n";
+        print $USER "#   Use '--blead' only with commits in blead branch.\n";
         exit 1;
 }
 $ENV{PERL_AUTOINSTALL} = "--defaultdeps";
@@ -634,7 +638,7 @@ my $DRY = $dry ? "-n" : "";
 
 if ( ! -e $perl_codespeed )
 {
-        print "*** BUILD perl\n";
+        print $USER "*** BUILD perl\n";
         # ========== configure ==========
 
         print_and_system "cd $build_path_perl; sh Configure -de -Dusedevel $USETHREADS $BIT64 $CONFARGS -Dprefix=$PREFIX";
@@ -658,7 +662,7 @@ if ( ! -e $perl_codespeed )
 
         print_and_system "cd $build_path_perl; make $DRY install";
 } else {
-        print "*** SKIP building perl - already existing.\n";
+        print $USER "*** SKIP building perl - already existing.\n";
 }
 
 # ========== perlformance utils ==========
@@ -692,10 +696,10 @@ my $PERL     = print_and_qx_chomp qq!ls -drt1 $PREFIX/bin/perl5.*.*     | tail -
 my $PERLDOC  = print_and_qx_chomp qq!ls -drt1 $PREFIX/bin/perldoc5.*.*  | tail -1!;
 my $POD2TEXT = print_and_qx_chomp qq!ls -drt1 $PREFIX/bin/pod2text5.*.* | tail -1!;
 
-print "# CPAN:     $CPAN\n";
-print "# PERL:     $PERL\n";
-print "# PERLDOC:  $PERLDOC\n";
-print "# POD2TEXT: $POD2TEXT\n";
+print $USER "# CPAN:     $CPAN\n";
+print $USER "# PERL:     $PERL\n";
+print $USER "# PERLDOC:  $PERLDOC\n";
+print $USER "# POD2TEXT: $POD2TEXT\n";
 
 my $bin_perl     = "$PREFIX/bin/perl";
 my $bin_cpan     = "$PREFIX/bin/cpan";
@@ -747,7 +751,7 @@ if ($cpan)
                 chomp $pid;
                 my $exists = kill 0, $pid;
                 if (not $exists) {
-                        print "Remove stale CPAN.pm lock.\n";
+                        print $USER "Remove stale CPAN.pm lock.\n";
                         print_and_system qq!rm -f $cpanlock!;
                 }
         }
@@ -755,7 +759,7 @@ if ($cpan)
         # optionally remove sources cache to avoid conflicts,
         # like happening with hot-patched CPAN mirrors (via Pinto)
         if ($cleancpansources) {
-                print "Remove $SOURCESDIR.\n";
+                print $USER "Remove $SOURCESDIR.\n";
                 print_and_system qq!rm -fr '$SOURCESDIR'!;
         }
 

--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -321,17 +321,25 @@ sub print_and_system {
         my $exitcode;
         my $line = caller_line();
 
-        open(STDOUT, ">&", $LOGFILE) || die;
-        open(STDERR, ">&", $LOGFILE) || die;
+        my @cmd = split / +/, $cmd;
+        my $bin = $cmd[0];
+        my $is_cpan = $bin eq bin_cpan();
 
-        print $COMMAND $cmd, "\n";
-        print $LOGFILE $cmd, "\n";
-        $exitcode = system ($cmd);
+        if (! $is_cpan) {
+                open(STDOUT, ">&", $LOGFILE) || die;
+                open(STDERR, ">&", $LOGFILE) || die;
 
-        open(STDOUT, ">&", $OLDSTDOUT) || die;
-        open(STDERR, ">&", $OLDSTDERR) || die;
+                print $COMMAND $cmd, "\n";
+                print $LOGFILE $cmd, "\n";
+                $exitcode = system ($cmd);
 
-        $exitcode == 0 || die "$0($line): $cmd ($exitcode>>".($exitcode>>8).")";
+                open(STDOUT, ">&", $OLDSTDOUT) || die;
+                open(STDERR, ">&", $OLDSTDERR) || die;
+
+                $exitcode == 0 || die "$0($line): $cmd ($exitcode>>".($exitcode>>8).")";
+        } else {
+                cpan_command(join(" ", @cmd[1..$#cmd]));
+        }
 }
 
 sub print_and_system_out {
@@ -724,6 +732,81 @@ print_and_system "if [ ! -e $bin_cpan     ] ; then ln -sf $CPAN     $bin_cpan   
 print_and_system "if [ ! -e $bin_perldoc  ] ; then ln -sf $PERLDOC  $bin_perldoc  ; fi";
 print_and_system "if [ ! -e $bin_pod2text ] ; then ln -sf $POD2TEXT $bin_pod2text ; fi";
 
+my $bin_cpan_helper  = "$build_path/cpan_helper.pl";
+my $pipe_cpan_helper = "$build_path/cpan_helper.out";
+my $log_cpan_helper  = "$build_path/cpan_helper.log";
+my $CPAN_COMMAND;
+my $CPAN_OUTPUT;
+
+my $text_cpan_helper = <<'END_HELPER';
+        use App::Cpan;
+        
+        my ($result_pipe, $logfile) = @ARGV;
+
+        open(my $LOGFILE, ">", $logfile) || die;
+        open(STDOUT, ">&", $LOGFILE) || die;
+        open(STDERR, ">&", \*STDOUT) || die;
+        print "*** HELPER_START ".localtime()."\n";
+
+        open(my $RESULT, ">", $result_pipe) || die;
+        my $ofh = select($RESULT); $| = 1; select($ofh);
+
+        my $has_cfg = 0;
+
+        while (my $cmd = <STDIN>) {
+                chomp $cmd;
+                print "*** COMMAND_START [$cmd]\n";
+
+                # pass cfg to run() only once
+                # run() uses @ARGV
+                @ARGV  = split / +/, $cmd;
+                if ($ARGV[0] eq '-j') {
+                        $has_cfg && do { @ARGV = @ARGV[2..$#ARGV] };
+                        $has_cfg = 1;
+                }
+                print "cmd now [", join(" ", @ARGV),"]\n";
+
+                my $rc = App::Cpan->run(@ARGV);
+                print "*** COMMAND_END [$rc] [$cmd]\n";
+                print $RESULT $rc, "\n";
+        }
+
+        END {
+                print "*** HELPER_END [$?] ".localtime()."\n";
+        }
+END_HELPER
+
+sub cpan_helper_setup {
+        # create helper script
+        open (my $fh_helper, ">", $bin_cpan_helper) || die;
+        print $fh_helper $text_cpan_helper || die;
+        close $fh_helper;
+
+        # create fifo, helper outputs result code to it
+        print_and_system("if [ ! -p $pipe_cpan_helper ]; then mkfifo $pipe_cpan_helper; fi");
+
+        # start helper
+        open ($CPAN_COMMAND, "|-", "$PERL $bin_cpan_helper $pipe_cpan_helper $log_cpan_helper") || die;
+        my $ofh = select $CPAN_COMMAND; $| = 1; select $ofh;
+        open ($CPAN_OUTPUT, "<", $pipe_cpan_helper) || die;
+}
+
+sub cpan_command {
+        my ($cmd) = @_;
+        $cmd =~ /\S+$/; my $mod = $&;
+        local $SIG{PIPE} = sub { die "missing helper" };
+        print $USER $mod, "\n";
+        print $COMMAND "cpan_command ", $cmd, "\n";
+        print $LOGFILE "cpan_command ", $cmd, "\n";
+        print $CPAN_COMMAND $cmd, "\n";
+        my $rc = <$CPAN_OUTPUT>; 
+        defined $rc || die "missing helper";
+        chomp $rc;
+        $rc == 0 || die "rc is $rc";
+}
+
+sub bin_cpan { $bin_cpan || "" }
+
 # ========== cpan ==========
 
 if ($cpan)
@@ -781,6 +864,8 @@ if ($cpan)
         # once upon a time the cpan exe missed the executable bit - set it to be sure
         print_and_system qq!chmod +x $CPAN!;
         print_and_system qq!chmod +x $bin_cpan!;
+
+        cpan_helper_setup();
 
         # install extended cpan toolchain; contains some "force" where we know they are really required
         print_and_system qq!$bin_cpan -j $CFG YAML::XS!;

--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -251,7 +251,7 @@ use Cwd "getcwd";
 
 my $HOME                = $ENV{HOME};
 
-my $build_path          = "/tmp/bootstrap-perl-build";
+our $build_path          = "/tmp/bootstrap-perl-build";
 my $build_path_perl     = "$build_path/perl";
 my $logfile             = "$build_path/bootstrap-perl.log";
 my $logcommand          = "$build_path/command.log";
@@ -265,7 +265,7 @@ my $dry;
 my $prefix;
 my $prefixbase          = "/opt";
 my $version             = "blead";
-my $VERSION;
+our $VERSION;
 my $installdeps;
 my $sourcetgz           = "/var/tmp/perl.tar.gz";
 my $blead               = 0;

--- a/bin/bootstrap-perl
+++ b/bin/bootstrap-perl
@@ -254,6 +254,7 @@ my $HOME                = $ENV{HOME};
 my $build_path          = "/tmp/bootstrap-perl-build";
 my $build_path_perl     = "$build_path/perl";
 my $logfile             = "$build_path/bootstrap-perl.log";
+my $logcommand          = "$build_path/command.log";
 my $giturl              = "git://github.com/Perl/perl5.git";
 
 my $cpucount             = `cat /proc/cpuinfo | grep bogomips | wc -l`; chomp $cpucount;
@@ -288,17 +289,21 @@ my @exesuffixes         = ();
 my $OLDSTDOUT;
 my $OLDSTDERR;
 my $LOGFILE;
+my $COMMAND;
 
 sub setup_log {
         open($OLDSTDOUT, ">&", \*STDOUT) || die;
         open($OLDSTDERR, ">&", \*STDERR) || die;
         open($LOGFILE,   ">" , $logfile) || die;
+        open($COMMAND,   ">",  $logcommand) || die;
 }
 
 sub print_and_system {
         my ($cmd) = @_;
         my $exitcode;
         my (undef, undef, $line) = caller;
+
+        print $COMMAND $cmd, "\n";
 
         open(STDOUT, ">&", $LOGFILE) || die;
         open(STDERR, ">&", $LOGFILE) || die;
@@ -315,6 +320,8 @@ sub print_and_system {
 sub print_and_system_out {
         my ($cmd) = @_;
         my (undef, undef, $line) = caller;
+        
+        print $COMMAND $cmd, "\n";
 
         print $cmd."\n";
         print $LOGFILE $cmd."\n";
@@ -329,6 +336,8 @@ sub print_and_qx {
         my $exitcode;
         my $out;
  
+        print $COMMAND $cmd, "\n";
+
         $out = qx($cmd 2>&1);
         $exitcode = $?;
         print $LOGFILE "$cmd\n$out\n";

--- a/xt/caller_line.t
+++ b/xt/caller_line.t
@@ -1,0 +1,23 @@
+use Test::More;
+our $no_run = 1;
+do "../bin/bootstrap-perl";
+
+is caller_line(), 5;
+
+sub func {
+        my $line = shift;
+        is caller_line(), $line;
+}
+func(11);
+
+sub func2 {
+        func(@_);
+}
+func2(16);
+
+eval <<'CODE';
+        is caller_line(), 1;
+        func(2);
+CODE
+
+done_testing();

--- a/xt/commands.t
+++ b/xt/commands.t
@@ -1,0 +1,173 @@
+use Test::More;
+
+do "dry_run.pl";
+
+ok $user eq <<'USER';
+
+============================================================
+Bootstrap Perl
+============================================================
+
+============================================================
+
+  Bootstrap Perl
+  --------------
+
+  version:        blead
+
+  git-describe:   v5.21.10-20-gada289e
+
+  git-changeset:  ada289e74406815f75328d011e5521339169abe7
+
+  codespeed name: perl-5.21-thread-no64bit
+
+  PREFIX:         /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e
+
+  configureargs:  
+
+  CPAN mirrors:   http://search.cpan.org/CPAN/
+
+  modules:        
+
+  scripts:        
+
+============================================================
+
+*** BUILD perl
+# CPAN:     /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.21.11
+# PERL:     /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11
+# PERLDOC:  /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc5.21.11
+# POD2TEXT: /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text5.21.11
+USER
+
+print "\$@ = [$@]\n" if $@;
+done_testing();
+
+__DATA__
+@ARGV = qw(--nouse64bit)
+
+# --- prepare
+
+= $build_path eq '/tmp/bootstrap-perl-build'
+mkdir -p /tmp/bootstrap-perl-build
+= ! -d $build_path
+cd /tmp/bootstrap-perl-build && git clone git://github.com/Perl/perl5.git perl
+cd /tmp/bootstrap-perl-build/perl && rm -f /tmp/bootstrap-perl-build/perl/.git/index.lock
+cd /tmp/bootstrap-perl-build/perl && git reset --hard
+cd /tmp/bootstrap-perl-build/perl && git clean -dxf
+cd /tmp/bootstrap-perl-build/perl && git checkout blead
+cd /tmp/bootstrap-perl-build/perl && git pull
+cd /tmp/bootstrap-perl-build/perl && git checkout blead
+cd /tmp/bootstrap-perl-build/perl && git pull
+
+cd /tmp/bootstrap-perl-build/perl && git describe --all
+< heads/blead
+cd /tmp/bootstrap-perl-build/perl && git describe
+< v5.21.10-20-gada289e
+cd /tmp/bootstrap-perl-build/perl && git rev-parse HEAD
+< ada289e74406815f75328d011e5521339169abe7
+
+= $VERSION eq v5.21.10
+
+git branch --contains ada289e74406815f75328d011e5521339169abe7
+< * blead
+
+# --- build perl
+
+cd /tmp/bootstrap-perl-build/perl; sh Configure -de -Dusedevel -Dusethreads   -Dprefix=/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e
+cd /tmp/bootstrap-perl-build/perl; make -j 2
+cd /tmp/bootstrap-perl-build/perl; make  install
+
+open > /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-gitdescribe
+chmod ugo+x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-gitdescribe
+
+open > /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-gitchangeset
+chmod ugo+x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-gitchangeset
+
+open > /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-codespeed-executable
+chmod ugo+x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl-codespeed-executable
+
+ls -drt1 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.*.*     | tail -1
+< /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.21.11
+
+ls -drt1 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.*.*     | tail -1
+< /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11
+
+ls -drt1 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc5.*.*  | tail -1
+< /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc5.21.11
+
+ls -drt1 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text5.*.* | tail -1
+< /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text5.21.11
+
+if [ ! -e /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl     ] ; then ln -sf /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11     /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl     ; fi
+
+if [ ! -e /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan     ] ; then ln -sf /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.21.11     /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan     ; fi
+
+if [ ! -e /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc  ] ; then ln -sf /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc5.21.11  /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc  ; fi
+
+if [ ! -e /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text ] ; then ln -sf /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text5.21.11 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/pod2text ; fi
+
+# --- prefs
+
+mkdir -p /tmp/bootstrap-perl-build
+cd /tmp/bootstrap-perl-build && git clone git://github.com/renormalist/cpanpm-distroprefs.git
+cd /tmp/bootstrap-perl-build/cpanpm-distroprefs && git pull
+cd /tmp/bootstrap-perl-build/cpanpm-distroprefs && git submodule update --init --recursive
+cd /tmp/bootstrap-perl-build/cpanpm-distroprefs && git pull
+mkdir -p /opt/cpan/prefs
+rsync -r /tmp/bootstrap-perl-build/cpanpm-distroprefs/cpanpm/distroprefs/ /opt/cpan/prefs/
+rsync -r /tmp/bootstrap-perl-build/cpanpm-distroprefs/renormalist/distroprefs/ /opt/cpan/prefs/
+rm -fr /opt/cpan/build
+
+# --- cpan config
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perldoc5.21.11 -l CPAN | sed -e "s/CPAN.pm/CPAN\/Config.pm/"
+< /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm
+
+open > /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm
+
+# --- cpan
+
+if [ -L /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -o ! -e /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan ] ; then /bin/rm /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan ; echo "force install CPAN" | /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MCPAN -e shell ; fi
+
+chmod +x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.21.11
+chmod +x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm YAML::XS
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm YAML
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm MSTROUT/YAML-0.84.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm MSTROUT/YAML-0.83.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm MSTROUT/YAML-0.82.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.81.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.80.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.79.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.78.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.77.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm INGY/YAML-0.76.tar.gz ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MYAML -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm -f -i YAML ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -MIO::Compress::Base -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm -f -i IO::Compress::Base ; fi 
+
+if ! /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 -M"version 0.97" -e1 ; then /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm -f -i version ; fi 
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm    -i YAML::Syck
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm    -i IO::Tty
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm    -i Expect
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm    -i Bundle::CPAN
+
+/opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm    -i LWP
+

--- a/xt/commands.t
+++ b/xt/commands.t
@@ -133,6 +133,12 @@ if [ -L /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -o ! -e /opt
 chmod +x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan5.21.11
 chmod +x /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan
 
+# cpan helper
+open > /tmp/bootstrap-perl-build/cpan_helper.pl
+if [ ! -p /tmp/bootstrap-perl-build/cpan_helper.out ]; then mkfifo /tmp/bootstrap-perl-build/cpan_helper.out; fi
+open |- /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/perl5.21.11 /tmp/bootstrap-perl-build/cpan_helper.pl /tmp/bootstrap-perl-build/cpan_helper.out /tmp/bootstrap-perl-build/cpan_helper.log
+open < /tmp/bootstrap-perl-build/cpan_helper.out
+
 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm YAML::XS
 
 /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/bin/cpan -j /opt/perl-5.21-thread-no64bit-v5.21.10-20-gada289e/lib/5.21.11/CPAN/Config.pm YAML

--- a/xt/dry_run.pl
+++ b/xt/dry_run.pl
@@ -129,14 +129,17 @@ sub test_cmd {
 
 sub core_open {
         test_cmd("open $_[1] $_[2]");
-      
+  
+        my $rw = $_[1];
+        $rw = $rw eq '|-'? '>': $rw;
+
         my $io_buf;
         if(defined($_[0])) {
-                CORE::open(qualify_to_ref($_[0]), $_[1], \$io_buf) || die;
+                CORE::open(qualify_to_ref($_[0]), $rw, \$io_buf) || die;
                 
         } else {
                 my $fh;
-                CORE::open($fh, $_[1], \$io_buf) || die;
+                CORE::open($fh, $rw, \$io_buf) || die;
                 $_[0] = $fh;
         }
         

--- a/xt/dry_run.pl
+++ b/xt/dry_run.pl
@@ -1,0 +1,152 @@
+use strict;
+use File::Basename;
+use Symbol; 
+use Test::More;
+
+our @data; chomp(@data = <DATA>);
+our $user;
+our $last_cmd;
+our $last_line;
+
+our $code_top = <<'CODE1';
+BEGIN {
+        use subs 'open', 'system';
+
+        sub open (*;$@) {
+                &core_open;
+        }
+        
+        sub system {
+                &core_system;
+        }
+};
+CODE1
+
+our $code_bottom = <<'CODE2';
+BEGIN {
+        no warnings; # sub redefined       
+        *print_and_system       = \&test_cmd;
+        *print_and_system_out   = \&test_cmd;
+        *print_and_qx           = \&test_cmd;
+        *setup_user             = sub {};
+        *setup_log              = sub {};
+
+        CORE::open($USER, ">", \$user) || die;
+
+        data_setvars();
+};
+CODE2
+
+sub dry_run {
+        # read bootstrap-perl code
+        my $app_path = dirname($0)."/../bin/bootstrap-perl";
+        open(my $fh, "<", $app_path) || die;
+        sysread($fh, my $code, -s $fh) || die;
+        
+        # reopen DATA handle
+        my $appdata;
+        $code =~ s/__DATA__\n(.*)$//s;
+        $appdata = $1;
+        open(DATA, "<", \$appdata) || die; 
+        
+        # add top and bottom code
+        $code =~ s/=cut\n/$&$code_top/s;
+        $code .= $code_bottom;
+
+       # run app
+        eval $code;
+        die $@ if $@;
+}
+
+sub data_setvars {
+        while ($data[0] =~ /^[\@|\$]/) {
+                my $varcode = shift(@data);
+                eval $varcode;
+        }
+}
+
+sub data_testcond {
+        while ($data[0] =~ /^=(.*)$/) {
+                my $cond = $1;
+                shift @data; data_skip(); # to show next cmd on fail
+                no strict 'vars';
+                ok eval($cond) or do {
+                        diag("see bootstrap-perl:$last_line\n".
+                                "last cmd=[$last_cmd]\n".
+                                "failed condition=[$cond]\n".
+                                "\$@=[$@]\n".
+                                "next expected=[$data[0]]"
+                                );
+                        die;
+                }
+        }
+}
+
+sub data_skip {
+        while ($data[0] eq "" || substr($data[0],0,1) eq "#") { 
+                @data > 0 || return;
+                shift @data;
+        }
+}
+
+sub data_next_cmd {
+        data_skip;
+        data_setvars;
+        data_testcond;
+        my $next = shift @data;
+        $next;
+}
+
+sub data_next_out {
+        my $out;
+        data_skip;
+        # may have several lines
+        while ($data[0] =~ /^\< /) {
+                # remove first "< "
+                $out .= substr($data[0], 2)."\n";
+                shift @data;
+                data_skip;
+        }
+        $out; 
+}
+
+sub test_cmd {
+        my $cmd = shift;
+        # print "[test_cmd] $cmd\n";
+        my $expected = data_next_cmd();
+
+        $last_cmd = $cmd;
+        $last_line = caller_line() - split(/\n/, $code_top);
+
+        ok($cmd eq $expected) or do {
+                diag("see bootstrap-perl:$last_line\n".
+                        "cmd=[$cmd]\n".
+                        "expected=[$expected]\n");
+                die;                        
+        };                
+        data_next_out();
+}
+
+sub core_open {
+        test_cmd("open $_[1] $_[2]");
+      
+        my $io_buf;
+        if(defined($_[0])) {
+                CORE::open(qualify_to_ref($_[0]), $_[1], \$io_buf) || die;
+                
+        } else {
+                my $fh;
+                CORE::open($fh, $_[1], \$io_buf) || die;
+                $_[0] = $fh;
+        }
+        
+        1;
+}
+
+sub core_system {
+        test_cmd(@_);
+        0;
+}
+
+dry_run();
+


### PR DESCRIPTION
This is just a technology preview, it is not meant to merge to master branch.
Bootstrap-perl runs cpan executable multiple times. And every time it is going to initialize CPAN.pm databases which is time-consuming. I offer to spawn cpan only once and use it as daemon.
